### PR TITLE
Leave CSP headers enabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+1.0.4
+  - CSP headers are enabled by default when you install this extension. You must
+    click the extention's button to disable CSP.
+
+1.0.3
+  - Fixes bad extension packaging of 1.0.2. Do not use 1.0.2.
+
+1.0.2
+  - Make the extension work for iframes.
+
+1.0.1
+  - Initial version.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Disable Content-Security-Policy in Chromium browers for web application testing.
 
-[Install] (https://chrome.google.com/webstore/detail/disable-content-security/ieelmcmcagommplceebfedjlakkhpden)
+[Install via the Chrome Web Store](https://chrome.google.com/webstore/detail/disable-content-security/ieelmcmcagommplceebfedjlakkhpden)
 
 ## Contributors
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,6 @@
+{
+  "extDescription": {
+    "message": "Disable Content-Security-Policy for web application testing. When the icon is colored, CSP headers are disabled. When the icon is gray, CSP headers are enabled.",
+    "description": "The description of this extention"
+  }
+}

--- a/_locales/en_GB/messages.json
+++ b/_locales/en_GB/messages.json
@@ -1,0 +1,6 @@
+{
+  "extDescription": {
+    "message": "Disable Content-Security-Policy for web application testing. When the icon is coloured, CSP headers are disabled. When the icon is grey, CSP headers are enabled.",
+    "description": "The description of this extention"
+  }
+}

--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
-var isActive = true;
+var isCSPDisabled = false;
 
-var callback = function(details) {
-  if (!isActive) {
+var onHeadersReceived = function(details) {
+  if (!isCSPDisabled) {
       return;
   }
 
@@ -16,19 +16,24 @@ var callback = function(details) {
   };
 };
 
+var updateUI = function() {
+  var iconName = isCSPDisabled ? 'on' : 'off';
+  var title    = isCSPDisabled ? 'disabled' : 'enabled';
+
+  chrome.browserAction.setIcon({ path: "images/icon38-" + iconName + ".png" });
+  chrome.browserAction.setTitle({ title: 'Content-Security-Policy headers are ' + title });
+};
+
 var filter = {
   urls: ["*://*/*"],
   types: ["main_frame", "sub_frame"]
 };
 
-chrome.webRequest.onHeadersReceived.addListener(callback, filter, ["blocking", "responseHeaders"]);
+chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, filter, ["blocking", "responseHeaders"]);
 
-
-chrome.browserAction.onClicked.addListener(function(tab) {
-    var state = isActive ? 'off' : 'on';
-    var details = {
-        path: "images/icon38-" + state + ".png"
-    };
-    chrome.browserAction.setIcon(details);
-    isActive = !isActive;
+chrome.browserAction.onClicked.addListener(function() {
+  isCSPDisabled = !isCSPDisabled;
+  updateUI()
 });
+
+updateUI();

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,7 @@
 {
   "name": "Disable Content-Security-Policy",
-  "description": "Disable content-security-policy for web application testing",
+  "default_locale": "en",
+  "description": "__MSG_extDescription__",
   "version": "1.0.3",
   "author": "Phil Grayson",
   "homepage_url": "https://github.com/PhilGrayson/chrome-csp-disable",

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Disable Content-Security-Policy",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Phil Grayson",
   "homepage_url": "https://github.com/PhilGrayson/chrome-csp-disable",
   "manifest_version": 2,

--- a/manifest.json
+++ b/manifest.json
@@ -16,13 +16,13 @@
     "persistent": true
   },
   "browser_action": {
-      "default_title": "Toggle Content-Security-Policy",
-      "default_icon": {
-          "16": "images/icon38-off.png"
-      }
+    "default_title": "Content-Security-Policy headers are enabled",
+    "default_icon": {
+      "16": "images/icon38-off.png"
+    }
   },
   "icons": {
-      "48": "images/icon48.png",
-      "128": "images/icon128.png"
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
   }
 }


### PR DESCRIPTION
Fixes issue #5

- Default state of this extension is to allow CSP headers. A user must
click the icon to disable CSP headers. This follows the principle of
least surprise.

- Fix incorrect icon being shown initially. The extension used to show
the greyed 'CSP headers enabled' icon when in fact the extension was
disabling CSP headers. When you clicked the icon, it continued to be
grey. A third click correctly toggled the state of the extension.

- Add a title/tooltip to explain if CSP headers are being disabled or
not.

- Update the extension description to explain the icon colours.