### PR TITLE
Fixes issues #4 and issue #11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+2.0.0
+  - CSP headers are disabled per tab.
 1.0.6
   - Fix the extension not working for https://web.whatsapp.com
 

--- a/background.js
+++ b/background.js
@@ -1,8 +1,34 @@
 /* global chrome */
-var isCSPDisabled = false;
+
+// List of tabIds where CSP headers are disabled
+var disabledTabIds = [];
+
+var isCSPDisabled = function (tabId) {
+  return disabledTabIds.includes(tabId);
+};
+
+var toggleDisableCSP = function (tabId) {
+  if (isCSPDisabled(tabId)) {
+    // remove this tabId from disabledTabIds
+    disabledTabIds = disabledTabIds.filter(function (val) {
+      return val !== tabId;
+    });
+  } else {
+    disabledTabIds.push(tabId);
+
+    // Sites that use Application Cache to cache their HTML document means this
+    // extension is not able to alter HTTP response headers (as there is no HTTP
+    // request when serving documents from the cache).
+    //
+    // An example page that this fixes is https://web.whatsapp.com
+    chrome.browsingData.remove({}, { serviceWorkers: true }, function () {});
+  }
+
+  updateUI(tabId);
+};
 
 var onHeadersReceived = function (details) {
-  if (!isCSPDisabled) {
+  if (!isCSPDisabled(details.tabId)) {
     return;
   }
 
@@ -17,30 +43,33 @@ var onHeadersReceived = function (details) {
   };
 };
 
-var updateUI = function () {
-  var iconName = isCSPDisabled ? 'on' : 'off';
-  var title = isCSPDisabled ? 'disabled' : 'enabled';
+var updateUI = function (tabId) {
+  var isDisabled = isCSPDisabled(tabId);
+  var iconName = isDisabled ? 'on' : 'off';
+  var title = isDisabled ? 'disabled' : 'enabled';
 
   chrome.browserAction.setIcon({ path: 'images/icon38-' + iconName + '.png' });
-  chrome.browserAction.setTitle({ title: 'Content-Security-Policy headers are ' + title });
+  chrome.browserAction.setTitle({ title: 'Content-Security-Policy headers are ' + title + ' for this tab' });
 };
 
-var filter = {
-  urls: ['*://*/*'],
-  types: ['main_frame', 'sub_frame']
+var init = function () {
+  // When Chrome recieves some headers
+  var onHeaderFilter = { urls: ['*://*/*'], types: ['main_frame', 'sub_frame'] };
+  chrome.webRequest.onHeadersReceived.addListener(
+    onHeadersReceived, onHeaderFilter, ['blocking', 'responseHeaders']
+  );
+
+  // When the user clicks the plugin icon
+  chrome.browserAction.onClicked.addListener(function (tab) {
+    toggleDisableCSP(tab.id);
+  });
+
+  // When the user changes tab
+  chrome.tabs.onActivated.addListener(function (activeInfo) {
+    updateUI(activeInfo.tabId);
+  });
+
+  // onAttached
 };
 
-chrome.webRequest.onHeadersReceived.addListener(
-  onHeadersReceived, filter, ['blocking', 'responseHeaders']
-);
-
-chrome.browserAction.onClicked.addListener(function () {
-  isCSPDisabled = !isCSPDisabled;
-
-  if (isCSPDisabled) {
-    chrome.browsingData.remove({}, { serviceWorkers: true }, function () {});
-  }
-
-  updateUI();
-});
-updateUI();
+init();

--- a/background.js
+++ b/background.js
@@ -1,12 +1,13 @@
+/* global chrome */
 var isCSPDisabled = false;
 
-var onHeadersReceived = function(details) {
+var onHeadersReceived = function (details) {
   if (!isCSPDisabled) {
-      return;
+    return;
   }
 
   for (var i = 0; i < details.responseHeaders.length; i++) {
-    if ('content-security-policy' === details.responseHeaders[i].name.toLowerCase()) {
+    if (details.responseHeaders[i].name.toLowerCase() === 'content-security-policy') {
       details.responseHeaders[i].value = '';
     }
   }
@@ -16,29 +17,30 @@ var onHeadersReceived = function(details) {
   };
 };
 
-var updateUI = function() {
+var updateUI = function () {
   var iconName = isCSPDisabled ? 'on' : 'off';
-  var title    = isCSPDisabled ? 'disabled' : 'enabled';
+  var title = isCSPDisabled ? 'disabled' : 'enabled';
 
-  chrome.browserAction.setIcon({ path: "images/icon38-" + iconName + ".png" });
+  chrome.browserAction.setIcon({ path: 'images/icon38-' + iconName + '.png' });
   chrome.browserAction.setTitle({ title: 'Content-Security-Policy headers are ' + title });
 };
 
 var filter = {
-  urls: ["*://*/*"],
-  types: ["main_frame", "sub_frame"]
+  urls: ['*://*/*'],
+  types: ['main_frame', 'sub_frame']
 };
 
-chrome.webRequest.onHeadersReceived.addListener(onHeadersReceived, filter, ["blocking", "responseHeaders"]);
+chrome.webRequest.onHeadersReceived.addListener(
+  onHeadersReceived, filter, ['blocking', 'responseHeaders']
+);
 
-chrome.browserAction.onClicked.addListener(function() {
+chrome.browserAction.onClicked.addListener(function () {
   isCSPDisabled = !isCSPDisabled;
 
   if (isCSPDisabled) {
-    chrome.browsingData.remove({}, {"serviceWorkers": true}, function () {});
+    chrome.browsingData.remove({}, { serviceWorkers: true }, function () {});
   }
 
-  updateUI()
+  updateUI();
 });
-
 updateUI();

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Disable Content-Security-Policy",
   "default_locale": "en",
   "description": "__MSG_extDescription__",
-  "version": "1.0.6",
+  "version": "2.0.0",
   "author": "Phil Grayson",
   "homepage_url": "https://github.com/PhilGrayson/chrome-csp-disable",
   "manifest_version": 2,


### PR DESCRIPTION
Content-Security-Policy header is now disabled per tab instead of globally. It is now harder to accidentally leave this extension enabled.